### PR TITLE
Add basic tests for core entities

### DIFF
--- a/internal/file_storage/file_storage_test.go
+++ b/internal/file_storage/file_storage_test.go
@@ -1,0 +1,41 @@
+package storage
+
+import (
+	"os"
+	"testing"
+
+	"telegram-tax-bot/internal/model"
+)
+
+func TestSaveAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	fs := NewFileStorage(dir)
+	data := model.UserData{ChatID: 42, Periods: []model.Period{{Country: "RU"}}}
+	if err := fs.Save(data); err != nil {
+		t.Fatalf("save error: %v", err)
+	}
+
+	loaded, err := fs.Load(42)
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if len(loaded.Periods) != 1 || loaded.ChatID != 42 {
+		t.Fatalf("loaded data mismatch: %+v", loaded)
+	}
+
+	if _, err := os.Stat(fs.file(42)); err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+}
+
+func TestLoadMissing(t *testing.T) {
+	dir := t.TempDir()
+	fs := NewFileStorage(dir)
+	loaded, err := fs.Load(99)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if loaded.ChatID != 99 || len(loaded.Periods) != 0 {
+		t.Fatalf("unexpected data: %+v", loaded)
+	}
+}

--- a/internal/manager/session_manager_test.go
+++ b/internal/manager/session_manager_test.go
@@ -1,0 +1,25 @@
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"telegram-tax-bot/internal/config"
+)
+
+func TestGetSession(t *testing.T) {
+	defer os.RemoveAll(config.DataDir)
+	s1 := GetSession(5)
+	if s1 == nil {
+		t.Fatal("expected session")
+	}
+	s2 := GetSession(5)
+	if s1 != s2 {
+		t.Fatal("session not cached")
+	}
+	expected := filepath.Join(config.DataDir, "5")
+	if s1.HistoryDir != expected {
+		t.Fatalf("dir mismatch: %s", s1.HistoryDir)
+	}
+}

--- a/internal/model/session_test.go
+++ b/internal/model/session_test.go
@@ -1,0 +1,40 @@
+package model
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsEmpty(t *testing.T) {
+	s := &Session{}
+	if !s.IsEmpty() {
+		t.Fatal("expected empty session")
+	}
+	s.Data.Periods = []Period{{Country: "RU"}}
+	if s.IsEmpty() {
+		t.Fatal("expected non-empty session")
+	}
+}
+
+func TestBuildPeriodsList(t *testing.T) {
+	s := &Session{Data: Data{Current: "01.01.2024", Periods: []Period{{In: "01.01.2024", Country: "Россия"}}}}
+	expected := "📋 Список периодов:\n\n1. 01.01.2024 — по 01.01.2024 (Россия)\n"
+	if list := s.BuildPeriodsList(); list != expected {
+		t.Fatalf("unexpected list: %s", list)
+	}
+}
+
+func TestSaveAndLoadSession(t *testing.T) {
+	dir := t.TempDir()
+	s := &Session{UserID: 1, HistoryDir: dir, Data: Data{Current: "01.01.2024", Periods: []Period{{In: "01.01.2024", Out: "02.01.2024", Country: "RU"}}}}
+	s.SaveSession()
+	var restored Session
+	restored.HistoryDir = dir
+	restored.LoadUserData()
+	if len(restored.Data.Periods) != 1 || restored.Data.Current != "01.01.2024" {
+		t.Fatal("session not restored correctly")
+	}
+	if _, err := os.Stat(dir + "/session.json"); err != nil {
+		t.Fatalf("session file not found: %v", err)
+	}
+}

--- a/internal/report_builder/report_builder_test.go
+++ b/internal/report_builder/report_builder_test.go
@@ -1,0 +1,25 @@
+package reportbuilder
+
+import (
+	"testing"
+
+	"telegram-tax-bot/internal/model"
+)
+
+func TestBuildReportSimple(t *testing.T) {
+	data := model.Data{
+		Current: "31.12.2023",
+		Periods: []model.Period{{In: "01.01.2023", Out: "31.12.2023", Country: "Россия"}},
+	}
+	got := BuildReport(data)
+	expected := "Анализ за период: 01.01.2023 — 31.12.2023\n\n🇷🇺 Россия: 365 дней\n\n✅ Налоговый резидент: 🇷🇺 Россия (365 дней)\n"
+	if got != expected {
+		t.Fatalf("unexpected report:\n%s", got)
+	}
+}
+
+func TestCountryToFlag(t *testing.T) {
+	if countryToFlag("RU") != "🇷🇺" {
+		t.Fatalf("wrong flag")
+	}
+}

--- a/internal/user_storage/user_storate_test.go
+++ b/internal/user_storage/user_storate_test.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"testing"
+
+	"telegram-tax-bot/internal/model"
+)
+
+type memStorage struct {
+	m map[int64]model.UserData
+}
+
+func (ms *memStorage) Load(id int64) (model.UserData, error) {
+	if d, ok := ms.m[id]; ok {
+		return d, nil
+	}
+	return model.UserData{ChatID: id}, nil
+}
+
+func (ms *memStorage) Save(d model.UserData) error {
+	ms.m[d.ChatID] = d
+	return nil
+}
+
+func TestUserStorage(t *testing.T) {
+	ms := &memStorage{m: make(map[int64]model.UserData)}
+	us := NewUserStorage(ms)
+	data := model.UserData{ChatID: 1, Periods: []model.Period{{Country: "RU"}}}
+	if err := us.SaveUser(data); err != nil {
+		t.Fatalf("save error: %v", err)
+	}
+	loaded, err := us.LoadUser(1)
+	if err != nil {
+		t.Fatalf("load error: %v", err)
+	}
+	if len(loaded.Periods) != 1 || loaded.ChatID != 1 {
+		t.Fatalf("loaded wrong data: %+v", loaded)
+	}
+}

--- a/internal/utils/date_worker_test.go
+++ b/internal/utils/date_worker_test.go
@@ -1,0 +1,19 @@
+package utils
+
+import "testing"
+
+func TestParseAndFormatDate(t *testing.T) {
+	d, err := ParseDate("01.02.2023")
+	if err != nil {
+		t.Fatalf("ParseDate returned error: %v", err)
+	}
+	if FormatDate(d) != "01.02.2023" {
+		t.Fatalf("expected 01.02.2023, got %s", FormatDate(d))
+	}
+}
+
+func TestParseDateInvalid(t *testing.T) {
+	if _, err := ParseDate("invalid"); err == nil {
+		t.Fatal("expected error for invalid date")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for date helpers
- test `Session` methods with temp directories
- cover file and user storage logic
- test report builder output
- ensure session manager caches sessions

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.2)*

------
https://chatgpt.com/codex/tasks/task_e_6840834105d88323b155ff0602024b29