### PR TITLE
Fix inline keyboard removal

### DIFF
--- a/internal/handler/callback.go
+++ b/internal/handler/callback.go
@@ -374,7 +374,13 @@ func formatPeriodList(periods []model.Period, current string) string {
 
 // removeInlineKeyboard clears the inline keyboard from a message without deleting the message itself.
 func removeInlineKeyboard(bot *tgbotapi.BotAPI, chatID int64, messageID int) {
+	// Telegram may return an error if the original message is too old or was
+	// already edited. We try to clear the markup and silently ignore any
+	// failure, falling back to deleting the message if editing is forbidden.
 	empty := tgbotapi.NewInlineKeyboardMarkup()
 	edit := tgbotapi.NewEditMessageReplyMarkup(chatID, messageID, empty)
-	_, _ = bot.Request(edit)
+	if _, err := bot.Request(edit); err != nil {
+		del := tgbotapi.NewDeleteMessage(chatID, messageID)
+		_, _ = bot.Request(del)
+	}
 }


### PR DESCRIPTION
## Summary
- delete the inline keyboard if editing fails

## Testing
- `go test ./...` *(fails: unable to download Go toolchain)*
- `go vet ./...` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6840a54cfee883238419b89d1133933c