### PR TITLE
Fix callback return

### DIFF
--- a/internal/handler/message.go
+++ b/internal/handler/message.go
@@ -46,6 +46,7 @@ func (r *Registry) handleMessage(msg *tgbotapi.Message) {
 		return
 	case "awaiting_add_open_country":
 		handleAddOpenCountry(msg, s, r.bot)
+		return
 	case "awaiting_tail_out":
 		handleAwaitingTailOut(msg, s, r.bot)
 		return
@@ -60,6 +61,7 @@ func (r *Registry) handleMessage(msg *tgbotapi.Message) {
 		return
 	case "awaiting_add_in":
 		handleAddin(msg, s, r.bot)
+		return
 	}
 
 	// ✅ Загрузка JSON-файла


### PR DESCRIPTION
## Summary
- add missing `return` when handling the `awaiting_add_in` and `awaiting_add_open_country` states

## Testing
- `go test ./...` *(fails: downloading toolchain Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840a725bc148323979768eb2ea7eeee