### PR TITLE
Fix inline keyboard removal

### DIFF
--- a/internal/handler/callback.go
+++ b/internal/handler/callback.go
@@ -376,11 +376,9 @@ func formatPeriodList(periods []model.Period, current string) string {
 func removeInlineKeyboard(bot *tgbotapi.BotAPI, chatID int64, messageID int) {
 	// Telegram may return an error if the original message is too old or was
 	// already edited. We try to clear the markup and silently ignore any
-	// failure, falling back to deleting the message if editing is forbidden.
+	// failure. Previously the message was deleted on failure, but that lead
+	// to losing the user's history. Now we simply ignore the error.
 	empty := tgbotapi.NewInlineKeyboardMarkup()
 	edit := tgbotapi.NewEditMessageReplyMarkup(chatID, messageID, empty)
-	if _, err := bot.Request(edit); err != nil {
-		del := tgbotapi.NewDeleteMessage(chatID, messageID)
-		_, _ = bot.Request(del)
-	}
+	_, _ = bot.Request(edit)
 }


### PR DESCRIPTION
## Summary
- don't delete messages when clearing inline keyboards

## Testing
- `go test ./...` *(fails: forbidden downloading go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6840a8e695888323a2204b8df59ca85e