### PR TITLE
Switch to reply keyboards

### DIFF
--- a/internal/handler/message.go
+++ b/internal/handler/message.go
@@ -70,12 +70,22 @@ func (r *Registry) handleMessage(msg *tgbotapi.Message) {
 		return
 	}
 
-	// ✅ Команды
+	// ✅ Команды и кнопки
 	switch {
-	case strings.HasPrefix(text, "/start"):
+	case strings.HasPrefix(text, "/start"), text == "🔙 Назад в меню":
 		handleStartCommand(s, msg, r.bot)
-	case strings.HasPrefix(text, "/help"):
+	case strings.HasPrefix(text, "/help"), text == "ℹ️ Помощь":
 		handleHelpCommand(msg, r.bot)
+	case text == "📎 Загрузить файл", text == "📎 Загрузить новый файл":
+		handleUploadCommand(s, msg, r.bot)
+	case text == "🗑 Сбросить":
+		handleResetCommand(s, msg, r.bot)
+	case text == "📅 Отчёт на заданную дату":
+		handleSetDateCommand(s, msg, r.bot)
+	case text == "📋 Показать текущие данные":
+		handlePeriodsCommand(s, msg, r.bot)
+	case text == "📊 Отчёт":
+		handleShowReport(s, msg, r.bot)
 	default:
 		if strings.HasPrefix(text, "{") {
 			handleJSONInput(msg, s, r.bot)

--- a/internal/keyboard/keyboards.go
+++ b/internal/keyboard/keyboards.go
@@ -6,32 +6,36 @@ import (
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
 
-func BuildBackToMenu() tgbotapi.InlineKeyboardMarkup {
-	return tgbotapi.NewInlineKeyboardMarkup(
-		tgbotapi.NewInlineKeyboardRow(
-			tgbotapi.NewInlineKeyboardButtonData("🔙 Назад в меню", "start"),
+func BuildBackToMenu() tgbotapi.ReplyKeyboardMarkup {
+	markup := tgbotapi.NewReplyKeyboard(
+		tgbotapi.NewKeyboardButtonRow(
+			tgbotapi.NewKeyboardButton("🔙 Назад в меню"),
 		),
 	)
+	markup.ResizeKeyboard = true
+	return markup
 }
 
-func BuildMainMenu(s *model.Session) tgbotapi.InlineKeyboardMarkup {
-	var buttons [][]tgbotapi.InlineKeyboardButton
+func BuildMainMenu(s *model.Session) tgbotapi.ReplyKeyboardMarkup {
+	var rows [][]tgbotapi.KeyboardButton
 
 	if s.IsEmpty() {
-		buttons = [][]tgbotapi.InlineKeyboardButton{
-			tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("📎 Загрузить файл", "upload_file")),
-			tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("ℹ️ Помощь", "help")),
+		rows = [][]tgbotapi.KeyboardButton{
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("📎 Загрузить файл")),
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("ℹ️ Помощь")),
 		}
 	} else {
-		buttons = [][]tgbotapi.InlineKeyboardButton{
-			tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("📋 Показать текущие данные", "periods")),
-			tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("📊 Отчёт", "show_report")),
-			tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("📅 Отчёт на заданную дату", "set_date")),
-			tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("📎 Загрузить новый файл", "upload_report")),
-			tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("🗑 Сбросить", "reset")),
-			tgbotapi.NewInlineKeyboardRow(tgbotapi.NewInlineKeyboardButtonData("ℹ️ Помощь", "help")),
+		rows = [][]tgbotapi.KeyboardButton{
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("📋 Показать текущие данные")),
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("📊 Отчёт")),
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("📅 Отчёт на заданную дату")),
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("📎 Загрузить новый файл")),
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("🗑 Сбросить")),
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("ℹ️ Помощь")),
 		}
 	}
 
-	return tgbotapi.NewInlineKeyboardMarkup(buttons...)
+	markup := tgbotapi.NewReplyKeyboard(rows...)
+	markup.ResizeKeyboard = true
+	return markup
 }


### PR DESCRIPTION
## Summary
- move main menu and back-to-menu keyboards to ReplyKeyboardMarkup
- handle text-based menu actions in message handler

## Testing
- `go vet ./...` *(fails: unable to download Go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6840a9c8e1d48323872ac254112af946