### PR TITLE
Fix cancel returning to main menu

### DIFF
--- a/internal/handler/message.go
+++ b/internal/handler/message.go
@@ -94,6 +94,9 @@ func (r *Registry) handleMessage(msg *tgbotapi.Message) {
 	case text == "❌ Отменить":
 		if strings.HasPrefix(s.PendingAction, "resolve_") {
 			handleCancelEdit(s, msg, r.bot)
+		} else if s.PendingAction == "" {
+			// Отмена выбора действия во время просмотра списка периодов
+			handlePeriodsCommand(s, msg, r.bot)
 		} else {
 			handleStartCommand(s, msg, r.bot)
 		}


### PR DESCRIPTION
## Summary
- handle cancel action inside periods view correctly

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68411c9706c4832390a01dfbc02b3f91