### PR TITLE
Add commands menu

### DIFF
--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -17,6 +17,16 @@ func New(token string) (*Bot, error) {
 	}
 
 	api.Debug = false
+	// set command menu similar to BotFather
+	commands := []tgbotapi.BotCommand{
+		{Command: "start", Description: "главное меню"},
+		{Command: "help", Description: "справка"},
+		{Command: "upload_report", Description: "загрузить данные"},
+		{Command: "periods", Description: "показать периоды"},
+		{Command: "reset", Description: "сбросить данные"},
+		{Command: "commands", Description: "список команд"},
+	}
+	_, _ = api.Request(tgbotapi.NewSetMyCommands(commands...))
 	return &Bot{API: api}, nil
 }
 

--- a/internal/handler/callback.go
+++ b/internal/handler/callback.go
@@ -116,6 +116,17 @@ func handleHelpCommand(msg *tgbotapi.Message, bot *tgbotapi.BotAPI) {
 	bot.Send(newMsg)
 }
 
+func handleCommandsCommand(msg *tgbotapi.Message, bot *tgbotapi.BotAPI) {
+	txt := `/start - главное меню
+/help - справка
+/upload_report - загрузить данные
+/periods - показать периоды
+/reset - сбросить данные`
+	newMsg := tgbotapi.NewMessage(msg.Chat.ID, txt)
+	newMsg.ReplyMarkup = keyboard.BuildBackToMenu()
+	bot.Send(newMsg)
+}
+
 func handleResetCommand(s *model.Session, msg *tgbotapi.Message, bot *tgbotapi.BotAPI) {
 	if s.IsEmpty() {
 		bot.Send(tgbotapi.NewMessage(msg.Chat.ID, "📭 У вас пока нет сохранённых периодов."))

--- a/internal/handler/message.go
+++ b/internal/handler/message.go
@@ -40,11 +40,20 @@ func (r *Registry) handleMessage(msg *tgbotapi.Message) {
 	case strings.HasPrefix(text, "/help"), text == "ℹ️ Помощь":
 		handleHelpCommand(msg, r.bot)
 		return
+	case strings.HasPrefix(text, "/commands"), text == "📖 Команды":
+		handleCommandsCommand(msg, r.bot)
+		return
 	case text == "📎 Загрузить файл", text == "📎 Загрузить новый файл":
 		handleUploadCommand(s, msg, r.bot)
 		return
-	case text == "🗑 Сбросить":
+	case strings.HasPrefix(text, "/upload_report"):
+		handleUploadCommand(s, msg, r.bot)
+		return
+	case text == "🗑 Сбросить", strings.HasPrefix(text, "/reset"):
 		handleResetCommand(s, msg, r.bot)
+		return
+	case strings.HasPrefix(text, "/periods"):
+		handlePeriodsCommand(s, msg, r.bot)
 		return
 	case text == "📅 Отчёт на заданную дату":
 		handleSetDateCommand(s, msg, r.bot)

--- a/internal/keyboard/keyboards.go
+++ b/internal/keyboard/keyboards.go
@@ -34,6 +34,7 @@ func BuildMainMenu(s *model.Session) tgbotapi.ReplyKeyboardMarkup {
 		rows = [][]tgbotapi.KeyboardButton{
 			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("📎 Загрузить файл")),
 			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("ℹ️ Помощь")),
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("📖 Команды")),
 		}
 	} else {
 		rows = [][]tgbotapi.KeyboardButton{
@@ -43,6 +44,7 @@ func BuildMainMenu(s *model.Session) tgbotapi.ReplyKeyboardMarkup {
 			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("📎 Загрузить новый файл")),
 			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("🗑 Сбросить")),
 			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("ℹ️ Помощь")),
+			tgbotapi.NewKeyboardButtonRow(tgbotapi.NewKeyboardButton("📖 Команды")),
 		}
 	}
 


### PR DESCRIPTION
## Summary
- add command list to keyboard menu
- support `/commands`, `/reset`, `/periods`, `/upload_report`
- register Telegram commands on startup

## Testing
- `go test ./...` *(fails: cannot download toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68412a5aefa083238553529f915b800e